### PR TITLE
Reset all dates to today

### DIFF
--- a/App.jsx
+++ b/App.jsx
@@ -358,6 +358,17 @@ function useDailySnapshot(storageKey, initialRows) {
   useEffect(() => { setMap(m => ensureSnapshot(m, date, initialRows)); }, [date]);
   useEffect(() => { setMap(m => ensureSnapshot(m, compare, initialRows)); }, [compare]);
   
+  // Ascultă un eveniment global pentru resetarea tuturor datelor la ziua de azi
+  useEffect(() => {
+    const handler = (e) => {
+      const k = e?.detail || keyForDate(new Date());
+      setDate(k);
+      setCompare(k);
+    };
+    window.addEventListener("app:resetAllDatesToToday", handler);
+    return () => window.removeEventListener("app:resetAllDatesToToday", handler);
+  }, []);
+  
   const rows = map[date] || initialRows;
   const setRows = (newRows) => {
     setMap(m => {
@@ -981,7 +992,11 @@ export default function App() {
               
               {/* DATA DE AZI CLICKABILĂ - NOUĂ FUNCȚIONALITATE */}
               <button
-                onClick={() => setGlobalDate(keyForDate(new Date()))}
+                onClick={() => {
+                  const k = keyForDate(new Date());
+                  setGlobalDate(k);
+                  window.dispatchEvent(new CustomEvent("app:resetAllDatesToToday", { detail: k }));
+                }}
                 className={`px-2 py-1 rounded-full text-xs border transition-all hover:scale-105 cursor-pointer ${
                   isDarkTheme 
                     ? "bg-white/15 text-white/80 border-white/20 hover:bg-white/25" 


### PR DESCRIPTION
Add global date reset functionality to set all tab dates and comparison dates to today when clicking the "Azi" button.

---
<a href="https://cursor.com/background-agent?bcId=bc-d359b5eb-3e5e-4e83-b8a9-93e47480a91f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d359b5eb-3e5e-4e83-b8a9-93e47480a91f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

